### PR TITLE
Playback with negative speed

### DIFF
--- a/AndroidTemplate/android_api.pde
+++ b/AndroidTemplate/android_api.pde
@@ -356,6 +356,15 @@ public class AudioPlayer implements Synth, AudioGenerator {
           readHead = 0;
           isPlaying = false;
         }
+      } else if (readHead < 0) {// got to the beginning
+        //% (float)audioData.length;
+        if (isLooping) {// back to the end for loop mode
+          readHead = audioData.length + (readHead % (float)audioData.length);
+        }
+        else {
+          readHead = audioData.length - 1;
+          isPlaying = false;
+        }
       }
 
       // linear interpolation here

--- a/DesktopTemplate/MaximJava_api.pde
+++ b/DesktopTemplate/MaximJava_api.pde
@@ -358,15 +358,24 @@ public class AudioPlayer implements Synth, AudioGenerator {
 	    short sample;
 	    readHead += dReadHead;
 	    if (readHead > (audioData.length - 1)) {// got to the end
-		//% (float)audioData.length;
-		if (isLooping) {// back to the start for loop mode
-		    readHead = readHead % (float)audioData.length;
-		}
-		else {
-		    readHead = 0;
-		    isPlaying = false;
-		}
-	    }
+			//% (float)audioData.length;
+			if (isLooping) {// back to the start for loop mode
+			    readHead = readHead % (float)audioData.length;
+			}
+			else {
+			    readHead = 0;
+			    isPlaying = false;
+			}
+	    } else if (readHead < 0) {// got to the beginning
+        	//% (float)audioData.length;
+        	if (isLooping) {// back to the end for loop mode
+          		readHead = audioData.length + (readHead % (float)audioData.length);
+        	}
+        	else {
+          		readHead = audioData.length - 1;
+          		isPlaying = false;
+        	}
+      	}
 
 	    // linear interpolation here
 	    // declaring these at the top...


### PR DESCRIPTION
Passing negative speed to AudioPlayer caused ArrayIndexOutOfBoundsException when current position was ahead of audio beginning. This patch adds looping for playing both forwards and backwards.

Unfortunately, according to https://bugs.webkit.org/show_bug.cgi?id=69725 Webkit doesn't support negative playbackRate for AudioBufferSourceNode, so this fix works only for java-based players
