### PR TITLE
Update maxim.js

### DIFF
--- a/JavaScriptTemplate/maxim.js
+++ b/JavaScriptTemplate/maxim.js
@@ -72,8 +72,9 @@ function Maxim(t) {
     }
 
     audio.cue = function(time) {
-
-	audio.stop();
+      if (audio.isPlaying()) {
+      	audio.stop();
+      }
       startTime=time/1000;
     }
 


### PR DESCRIPTION
According to the WebAudio spec:
“stop must only be called one time and only after a call to start or stop, or an exception will be thrown.”

In some loops where one would call cue without prior checking that start had been called, an exception would be thrown causing the audio to stop.
In earlier versions of Chrome (<31) the exception wasn't thrown, so it did work.
See https://code.google.com/p/chromium/issues/detail?id=330534#c6 for details.

Checking that the sound is playing before calling stop ensures that start had been called at least once before calling stop.
