### PR TITLE
Update maxim.js

### DIFF
--- a/JavaScriptTemplate/maxim.js
+++ b/JavaScriptTemplate/maxim.js
@@ -44,7 +44,11 @@ function Maxim(t) {
         myAudioBuffer = buffer;
         //       alert("sound decoded"); //test
         source = context.createBufferSource();
-        gainNode = context.createGainNode();
+        
+        //createGainNode method is deprecated :(
+        //gainNode = context.createGainNode();
+        gainNode = context.createGainNode ? context.createGainNode() : context.createGain();
+        
         filter = context.createBiquadFilter();
         analyser = context.createAnalyser();
         filter.type = 0;


### PR DESCRIPTION
AudioContext.createGainNode is now deprecated (current version of the spec [1]), and should use AudioContext.createGain instead
